### PR TITLE
storaged: Migrate to Enhanced ACG

### DIFF
--- a/files/sysbus/com.palm.storage.api.json
+++ b/files/sysbus/com.palm.storage.api.json
@@ -1,5 +1,5 @@
 {
-    "system": [
+    "storaged.operation": [
         "com.palm.storage/diskmode/changed",
         "com.palm.storage/diskmode/avail",
         "com.palm.storage/diskmode/enterMSM",

--- a/files/sysbus/com.palm.storage.perm.json
+++ b/files/sysbus/com.palm.storage.perm.json
@@ -1,7 +1,6 @@
 {
     "com.palm.storage": [ 
-        "system",
-        "settings"
+        "storaged.operation"
     ]
 }
 

--- a/files/sysbus/com.palm.storage.role.json.in
+++ b/files/sysbus/com.palm.storage.role.json.in
@@ -1,5 +1,6 @@
 {
     "exeName":"@WEBOS_INSTALL_SBINDIR@/storaged",
+    "trustLevel": "oem",
     "type": "regular",
     "allowedNames": ["com.palm.storage"],
     "permissions": [


### PR DESCRIPTION
In order to be able to use latest components from upstream webOS OSE.4

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
