### PR TITLE
Fix invalid rule warning at startup

### DIFF
--- a/files/conf/90-storaged.rules.in
+++ b/files/conf/90-storaged.rules.in
@@ -17,7 +17,7 @@
 # LICENSE@@@
 
 
-KERNEL=="usb_gadget", SUBSYSTEM=="platform", DRIVER=="usb_gadget", ENV{G_SUBSYSTEM}=="storage", ACTION=="change", RUN+="@WEBOS_INSTALL_SYSCONFDIR@/udev/scripts/storage.sh $ENV{G_ACTION} $ENV{G_MEDIA_LOADED}$ENV{G_HOST_CONNECTED}$ENV{G_MEDIA_REQUESTED}$ENV{G_BUS_SUSPENDED}"
+KERNEL=="usb_gadget", SUBSYSTEM=="platform", DRIVER=="usb_gadget", ENV{G_SUBSYSTEM}=="storage", ACTION=="change", RUN+="/bin/sh -c '/etc/udev/scripts/storage.sh $env{G_ACTION} $env{G_MEDIA_LOADED} $env{G_HOST_CONNECTED} $env{G_MEDIA_REQUESTED} $env{G_BUS_SUSPENDED}'"
 SUBSYSTEM=="android_usb", ACTION=="change", ATTR{state}=="CONFIGURED", RUN+="@WEBOS_INSTALL_SYSCONFDIR@/udev/scripts/storage.sh HOST_STATE_CHANGED 1"
 SUBSYSTEM=="android_usb", ACTION=="change", ATTR{state}=="DISCONNECTED", RUN+="@WEBOS_INSTALL_SYSCONFDIR@/udev/scripts/storage.sh HOST_STATE_CHANGED 0"
 

--- a/scripts/public/storage.sh.in
+++ b/scripts/public/storage.sh.in
@@ -27,34 +27,40 @@ ErrPrint() {
     logger -t udev_storaged -p err "$@"
 }
 
-DbgPrint "$0($1,$2) called: "
+DbgPrint "$0($1,$2,$3,$4,$5) called: "
 
-action="$1"
-change="$2"
+ACTION="$1"
+MEDIA_LOADED="$2"
+HOST_CONNECTED="$3"
+MEDIA_REQUESTED="$4"
+BUS_SUSPENDED="$5"
+CHANGE="${MEDIA_LOADED}${HOST_CONNECTED}${MEDIA_REQUESTED}${BUS_SUSPENDED}"
 
-if [ "$action" == "HOST_STATE_CHANGED" ]; then
+if [ "$ACTION" == "HOST_STATE_CHANGED" ]; then
     method="changed"
     change_name="connected"
-elif [ "$action" == "MEDIA_STATE_CHANGED" ]; then
+elif [ "$ACTION" == "MEDIA_STATE_CHANGED" ]; then
     method="avail"
     change_name="connected"
-elif [ "$action" == "MEDIA_REQUEST_STATE_CHANGED" ]; then
+elif [ "$ACTION" == "MEDIA_REQUEST_STATE_CHANGED" ]; then
     method="requestMedia"
     change_name="connected"
-elif [ "$action" == "BUS_STATE_CHANGED" ]; then
+elif [ "$ACTION" == "BUS_STATE_CHANGED" ]; then
     method="busSuspended"
     change_name="suspended"
 else
-    ErrPrint "unknown action $action passed to $0"
+    ErrPrint "unknown action $ACTION passed to $0"
     return
 fi
 
-if [ "$change" == "0" ]; then
+# TODO: If more than one of the change variables is set, this script will not know how to deal with it.  It never has known, though.
+# Probably need to check with a Legacy webOS device, to see how it handled this situation, and model something after that.
+if [ "$CHANGE" == "0" ]; then
     MESSAGE="{\"$change_name\": false}"
-elif [ "$change" == "1" ]; then
+elif [ "$CHANGE" == "1" ]; then
     MESSAGE="{\"$change_name\": true}"
 else
-    ErrPrint "unexpected change $change passed to $0"
+    ErrPrint "unexpected change $CHANGE passed to $0"
     return
 fi
 


### PR DESCRIPTION
"systemd-udevd[52]: /etc/udev/rules.d/90-storaged.rules:20 Invalid value "/etc/udev/scripts/storage.sh $ENV{G_ACTION} $ENV{G_MEDIA_LOADED}$ENV{G_HOST_CONNECTED}$ENV{G_MEDIA_REQUESTED}$ENV{G_BUS_SUSPENDED}" for RUN (char 30: invalid substitution type), ignoring."

It is not clear that this will actually make usb gadget functionality work, but it's a step there.  We should get ahold of a legacy system and see how this is handled.
